### PR TITLE
Create logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import logging
 from argparse import ArgumentParser
@@ -58,7 +57,8 @@ def main():
         if config.get("schedule"):
             yin_yang.start_daemon()
         else:
-            logger.warning(
+            logger.warning("Tried to start scheduler, but schedule was not enabled.")
+            print(
                 "Looks like you have not specified a time."
                 "You can use the GUI by running Yin & Yang or "
                 "edit the config found in ~/.config/yin_yang/yin_yang.json."

--- a/main.py
+++ b/main.py
@@ -1,11 +1,17 @@
+import logging
 import sys
+import logging
 from argparse import ArgumentParser
-from src import yin_yang
-from src import config
-from src import gui
+from pathlib import Path
+
 from PyQt5 import QtWidgets
 from PyQt5 import QtCore
 
+from src import yin_yang
+from src import config
+from src import gui
+
+logger = logging.getLogger(__name__)
 
 # fix HiDpi scaling
 QtWidgets.QApplication.setAttribute(
@@ -43,7 +49,7 @@ def main():
     # checks whether the script should be ran as a daemon
     if args.schedule:
         config.update("running", False)
-        print("START thread listener")
+        logger.debug("START thread listener")
 
         if config.get("followSun"):
             # calculate time if needed
@@ -52,10 +58,11 @@ def main():
         if config.get("schedule"):
             yin_yang.start_daemon()
         else:
-            print("looks like you did not specified a time")
-            print("You can use the gui with yin-yang -gui")
-            print("Or edit the config found in ~/.config/yin_yang/yin_yang.json")
-            print("You need to set schedule to True and edit the time to toggles")
+            logger.warning(
+                "Looks like you have not specified a time."
+                "You can use the GUI by running Yin & Yang or "
+                "edit the config found in ~/.config/yin_yang/yin_yang.json."
+                "You need to set schedule to true and edit the time to toggles.")
 
     if args.toggle:
         # terminate any running instances
@@ -66,4 +73,19 @@ def main():
 
 
 if __name__ == "__main__":
+    # __debug__ is true when main.py is run without the -o argument.
+    if __debug__:
+        # noinspection SpellCheckingInspection
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format='%(asctime)s %(levelname)s - %(name)s: %(message)s'
+        )
+    else:
+        # logger to see what happens when application is running in background
+        # noinspection SpellCheckingInspection
+        logging.basicConfig(
+            filename=str(Path.home()) + '/.local/share/yin_yang.log',
+            level=logging.WARNING,
+            format='%(asctime)s %(levelname)s - %(name)s: %(message)s'
+        )
     main()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import sys
 import logging
 from argparse import ArgumentParser
+from logging.handlers import TimedRotatingFileHandler, RotatingFileHandler
 from pathlib import Path
 
 from PyQt5 import QtWidgets
@@ -74,7 +75,7 @@ def main():
 
 
 if __name__ == "__main__":
-    # __debug__ is true when main.py is run without the -O argument.
+    # __debug__ is true when you run main.py without the -O argument (python main.py)
     if __debug__:
         # noinspection SpellCheckingInspection
         logging.basicConfig(
@@ -82,11 +83,18 @@ if __name__ == "__main__":
             format='%(asctime)s %(levelname)s - %(name)s: %(message)s'
         )
     else:
-        # logger to see what happens when application is running in background
+        # if you run it with "python -O main.py" instead, debug is false
+
+        # let the default logger print to the console
         # noinspection SpellCheckingInspection
         logging.basicConfig(
-            filename=str(Path.home()) + '/.local/share/yin_yang.log',
             level=logging.WARNING,
             format='%(asctime)s %(levelname)s - %(name)s: %(message)s'
         )
+        # and add a handler that limits the size to 1 GB
+        file_handler = RotatingFileHandler(
+            str(Path.home()) + '/.local/share/yin_yang.log',
+            maxBytes=10**9, backupCount=1
+        )
+        logging.root.addHandler(file_handler)
     main()

--- a/main.py
+++ b/main.py
@@ -62,7 +62,8 @@ def main():
                 "Looks like you have not specified a time."
                 "You can use the GUI by running Yin & Yang or "
                 "edit the config found in ~/.config/yin_yang/yin_yang.json."
-                "You need to set schedule to true and edit the time to toggles.")
+                "You need to set schedule to true and edit the time to toggles."
+            )
 
     if args.toggle:
         # terminate any running instances

--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ def main():
 
 
 if __name__ == "__main__":
-    # __debug__ is true when main.py is run without the -o argument.
+    # __debug__ is true when main.py is run without the -O argument.
     if __debug__:
         # noinspection SpellCheckingInspection
         logging.basicConfig(

--- a/src/config.py
+++ b/src/config.py
@@ -6,9 +6,7 @@ import re
 from suntime import Sun, SunTimeException
 
 logger = logging.getLogger(__name__)
-
 assembly_version = 2.2
-
 # aliases for path to use later on
 home = os.getenv("HOME")
 path = home + "/.config"
@@ -56,15 +54,17 @@ def set_sun_time():
         today_sr = sun.get_local_sunrise_time()
         today_ss = sun.get_local_sunset_time()
 
-        logger.debug('Today the sun raised at {} and get down at {}'.
-              format(today_sr.strftime('%H:%M'), today_ss.strftime('%H:%M')))
+        logger.debug(
+            f'Today the sun raised at {today_sr.strftime("%H:%M")} and '
+            f'gets down at {today_ss.strftime("%H:%M")}'
+        )
 
         # Get today's sunrise and sunset in UTC
         update("switchToLight", today_sr.strftime('%H:%M'))
         update("switchToDark", today_ss.strftime('%H:%M'))
 
     except SunTimeException as e:
-        logger.error("Error: {0}.".format(e))
+        logger.error(f"Error: {e}.")
 
 
 # generate path for yin-yang if there is none this will be skipped

--- a/src/config.py
+++ b/src/config.py
@@ -54,11 +54,6 @@ def set_sun_time():
         today_sr = sun.get_local_sunrise_time()
         today_ss = sun.get_local_sunset_time()
 
-        logger.debug(
-            f'Today the sun raised at {today_sr.strftime("%H:%M")} and '
-            f'gets down at {today_ss.strftime("%H:%M")}'
-        )
-
         # Get today's sunrise and sunset in UTC
         update("switchToLight", today_sr.strftime('%H:%M'))
         update("switchToDark", today_ss.strftime('%H:%M'))

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,11 @@
 import json
+import logging
 import os
 import pathlib
 import re
 from suntime import Sun, SunTimeException
+
+logger = logging.getLogger(__name__)
 
 assembly_version = 2.2
 
@@ -53,7 +56,7 @@ def set_sun_time():
         today_sr = sun.get_local_sunrise_time()
         today_ss = sun.get_local_sunset_time()
 
-        print('Today the sun raised at {} and get down at {}'.
+        logger.debug('Today the sun raised at {} and get down at {}'.
               format(today_sr.strftime('%H:%M'), today_ss.strftime('%H:%M')))
 
         # Get today's sunrise and sunset in UTC
@@ -61,7 +64,7 @@ def set_sun_time():
         update("switchToDark", today_ss.strftime('%H:%M'))
 
     except SunTimeException as e:
-        print("Error: {0}.".format(e))
+        logger.error("Error: {0}.".format(e))
 
 
 # generate path for yin-yang if there is none this will be skipped

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 import os
 import sys
@@ -10,6 +11,8 @@ from src.plugins import plugins
 from src.ui.mainwindow import Ui_MainWindow
 from src.ui.settings import Ui_MainWindow as Ui_SettingsWindow
 from src import yin_yang
+
+logger = logging.getLogger(__name__)
 
 
 class SettingsWindow(QtWidgets.QMainWindow):
@@ -30,7 +33,7 @@ class SettingsWindow(QtWidgets.QMainWindow):
         self.save_and_exit()
 
     def save_and_exit(self):
-        print("saving options")
+        logger.debug("saving options")
 
         for plugin in plugins:
             widget: QtWidgets.QGroupBox = self.ui.plugins_scroll_content.findChild(QtWidgets.QGroupBox, f'group{plugin.name}')

--- a/src/yin_yang.py
+++ b/src/yin_yang.py
@@ -12,6 +12,7 @@ license: MIT
 """
 
 import datetime
+import logging
 import os
 import pwd
 import subprocess
@@ -23,6 +24,8 @@ import traceback
 import src.yin_yang
 from src import config
 from src.plugins import plugins
+
+logger = logging.getLogger(__name__)
 
 # aliases for path to use later on
 user = pwd.getpwuid(os.getuid())[0]
@@ -42,12 +45,12 @@ class Yang(threading.Thread):
                 continue
 
             if pl.enabled:
-                print('Changing theme in plugin ' + pl.name)
+                logger.info('Changing theme in plugin ' + pl.name)
                 try:
                     if not pl.set_mode(False):
                         raise ValueError('set_mode() did not return True.')
                 except Exception as e:
-                    print('Error while changing the theme in plugin ' + pl.name)
+                    logger.error('Error while changing the theme in plugin ' + pl.name)
                     traceback.print_exception(type(e), e, e.__traceback__)
         play_sound("./assets/light.wav")
 
@@ -63,12 +66,12 @@ class Yin(threading.Thread):
                 continue
 
             if pl.enabled:
-                print('Changing theme in plugin ' + pl.name)
+                logger.info('Changing theme in plugin ' + pl.name)
                 try:
                     if not pl.set_mode(True):
                         raise ValueError('set_mode() did not return True.')
                 except Exception as e:
-                    print('Error while changing the theme in plugin ' + pl.name)
+                    logger.error('Error while changing the theme in plugin ' + pl.name)
                     traceback.print_exception(type(e), e, e.__traceback__)
         play_sound("./assets/dark.wav")
 


### PR DESCRIPTION
In this pull request, I added the creation of a log file at _~/.local/share/yin_yang.log_. Basically, most of the print statements are now logs.
Exception for this are the print in the Firefox and gnome plugin that remind the user that they need to have the extensions installed.

Running the tool with `python main.py` prints all logs (debug level and above) to the console. With `python -o main.py`, logs on level "warning :warning:" and above go into the above-mentioned file.