### PR TITLE
Fix: Not all vscode themes are available in the combo box

### DIFF
--- a/src/plugins/_plugin.py
+++ b/src/plugins/_plugin.py
@@ -102,7 +102,9 @@ class Plugin(ABC):
 
             # add all theme names
             for inp in inputs:
-                for theme in self.available_themes.values():
+                themes = list(self.available_themes.values())
+                themes.sort()
+                for theme in themes:
                     inp.addItem(theme)
 
             return inputs

--- a/src/plugins/vscode.py
+++ b/src/plugins/vscode.py
@@ -119,7 +119,6 @@ class Vscode(Plugin):
 
                 except FileNotFoundError as e:
                     logger.error(str(e))
-                    themes_dict = {}
                     break
 
         assert themes_dict != {}, 'No themes found'


### PR DESCRIPTION
Hi!

I've noticed that only few of my vscode themes were available in the combo boxes. I traced down the issue.
Also I've added the alphabetical sort to the available options for ease of search