### PR TITLE
Add vscode extensions path for ubuntu

### DIFF
--- a/src/plugins/vscode.py
+++ b/src/plugins/vscode.py
@@ -12,6 +12,7 @@ extension_paths = [
     str(Path.home()) + '/.vscode/extensions',
     str(Path.home()) + '/.vscode-oss/extensions',
     '/usr/lib/code/extensions',
+    '/usr/share/code/resources/app/extensions',
     '/opt/visual-studio-code/resources/app/extensions/',
     '/var/lib/snapd/snap/code/current/usr/share/code/resources/app/extensions/'
 ]


### PR DESCRIPTION
On my ubuntu installation for vscode the extension path is different.

Fixes #139 