### PR TITLE
Konsole: Allow to select user-installed theme

### DIFF
--- a/src/plugins/konsole.py
+++ b/src/plugins/konsole.py
@@ -1,8 +1,7 @@
 import logging
 from configparser import ConfigParser
-from os import scandir
-from os.path import isdir
 from pathlib import Path
+from itertools import chain
 
 from src.plugins._plugin import Plugin
 
@@ -11,6 +10,11 @@ logger = logging.getLogger(__name__)
 
 class Konsole(Plugin):
     global_path = '/usr/share/konsole'
+
+    @property
+    @staticmethod
+    def user_path() -> Path:
+        return Path.home() / '.local/share/konsole'
 
     def __init__(self):
         super().__init__()
@@ -21,14 +25,15 @@ class Konsole(Plugin):
         config = ConfigParser()
         # leave casing as is
         config.optionxform = str
-        user_path = str(Path.home()) + '/.local/share/konsole'
-        with scandir(user_path) as entries:
-            files = [f.path for f in entries if f.is_file() and f.name.endswith('.profile')]
+        config_paths = [
+            p for p in self.user_path.iterdir()
+            if f.is_file() and f.suffix == '.profile'
+        ]
 
-        assert len(files) > 0, 'No profiles found!'
+        assert len(config_paths) > 0, 'No profiles found!'
 
-        for config_file in files:
-            config.read(config_file)
+        for config_path in config_paths:
+            config.read(config_path)
 
             try:
                 config['Appearance']['ColorScheme'] = theme
@@ -44,14 +49,14 @@ class Konsole(Plugin):
                 else:
                     raise e
 
-                with open(config_file, 'w+') as file:
+                with config_path.open('w+') as file:
                     config.write(file)
 
                 self.set_theme(theme)
                 logger.info('Success!')
                 return
 
-            with open(config_file, 'w') as file:
+            with config_path.open('w') as file:
                 config.write(file)
 
     @property
@@ -59,17 +64,17 @@ class Konsole(Plugin):
         if not self.available:
             return {}
 
-        with scandir(self.global_path) as entries:
-            themes_machine = list(
-                f.name.replace('.colorscheme', '') for f in entries
-                if f.is_file() and f.name.endswith('.colorscheme'))
-        themes_machine.sort()
+        themes = sorted([
+            p.with_suffix('')
+            for p in chain(self.global_path.iterdir(), self.user_path.iterdir())
+            if p.is_file() and f.suffix == '.colorscheme'
+        ])
 
         themes_dict = {}
         config_parser = ConfigParser()
 
-        for theme in themes_machine:
-            config_parser.read(f'{self.global_path}/{theme}.colorscheme')
+        for theme in themes:
+            config_parser.read(self.global_path / f'{theme}.colorscheme')
             theme_name = config_parser['General']['Description']
             themes_dict[theme] = theme_name
 
@@ -78,4 +83,4 @@ class Konsole(Plugin):
 
     @property
     def available(self) -> bool:
-        return isdir(self.global_path)
+        return self.global_path.is_dir()


### PR DESCRIPTION
If you use get-hot-new-stuff to download konsole themes, they end up in the user directory. This PR allows to select those.