### PR TITLE
Improve installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then you can install Yin-Yang in a python virtual environment:
 ```bash
 bash
 rm -rf Yin-Yang
-git clone https://github.com/oskarsh/Yin-Yang && cd Yin-Yang
+git clone https://github.com/oskarsh/Yin-Yang
 if pwd != "Yin-Yang"; then cd Yin-Yang; fi
 ## Create virtual environment for pypi packages
 python3 -m venv .venv

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ For CentOS, RHEL, and Fedora:
 sudo dnf install gcc systemd-devel
 ``` 
 
+For OpenSUSE:
+```bash
+sudo zypper refresh
+sudo zypper install gcc systemd-devel
+```
+
 For Debian, Ubuntu, etc.
 ```bash
 sudo apt update
@@ -60,16 +66,20 @@ sudo apt install libsystemd-dev gcc pkg-config python3-dev
 
 Then you can install Yin-Yang in a python virtual environment:
 ```bash
+# bash is necessary to run the source command
 bash
+# Removes any already present Yin-Yang code
 rm -rf Yin-Yang
+# Clones the code to your local machine
 git clone https://github.com/oskarsh/Yin-Yang
+# Enters the directory containing Yin-Yang's code
 if pwd != "Yin-Yang"; then cd Yin-Yang; fi
-## Create virtual environment for pypi packages
+## Creates a virtual environment for pypi (pip) packages
 python3 -m venv .venv
 source .venv/bin/activate
-# Install pip requirements
+# Installs pip requirements specified in repository
 pip3 install -r requirements.txt
-# Install Yin-Yang
+# Installs Yin-Yang
 ./scripts/install.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ sudo apt install libsystemd-dev gcc pkg-config python3-dev
 
 Then you can install Yin-Yang in a python virtual environment:
 ```bash
+bash
 git clone https://github.com/oskarsh/Yin-Yang && cd Yin-Yang
 ## Create virtual environment for pypi packages
 python3 -m venv .venv

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ sudo apt install libsystemd-dev gcc pkg-config python3-dev
 Then you can install Yin-Yang in a python virtual environment:
 ```bash
 bash
+rm -rf Yin-Yang
 git clone https://github.com/oskarsh/Yin-Yang && cd Yin-Yang
+if pwd != "Yin-Yang"; then cd Yin-Yang; fi
 ## Create virtual environment for pypi packages
 python3 -m venv .venv
 source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ bash
 # Removes any already present Yin-Yang code
 rm -rf Yin-Yang
 # Clones the code to your local machine
-git clone https://github.com/oskarsh/Yin-Yang
+git clone https://github.com/oskarsh/Yin-Yang.git
 # Enters the directory containing Yin-Yang's code
 if pwd != "Yin-Yang"; then cd Yin-Yang; fi
 ## Creates a virtual environment for pypi (pip) packages


### PR DESCRIPTION
-	# **https://github.com/oskarsh/Yin-Yang/pull/206/commits/316d49ba67ee4565edcb75be3a844a8c64e27da6**

	```bash
	source
	```

	is a `bash`ism. This means that the user has to invoke the code with bash for it to invoke correctly:

	```log
	pwsh
	PowerShell 7.3.4
	PS /home/rokejulianlockhart/Yin-Yang> source .venv/bin/activate
	source: The term 'source' is not recognized as a name of a cmdlet, function, script file, or executable program.
	Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
	PS /home/rokejulianlockhart/Yin-Yang>
	```

	Just setting the syntax highlighting to `bash` isn't enough; the code needs to invoke a bash shell for a user to be able to merely copy-paste it.


-	# **https://github.com/oskarsh/Yin-Yang/pull/206/commits/bcb66fb2eb288b382ef6e51b2065cac930b35ef6**

	If the `git` repository already exists locally, the current code won't automatically `cd` the user into it.