### PR TITLE
Add 'python3-devel' in Source section for RPM systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Yin-Yang depends on `python-systemd` and `pyside6` from pypi. `python-systemd` r
 
 For CentOS, RHEL, and Fedora:
 ```bash
-sudo dnf install gcc systemd-devel
+sudo dnf install gcc systemd-devel python3-devel
 ``` 
 
 For Debian, Ubuntu, etc.


### PR DESCRIPTION
'python3-devel' package is also required for RPM systems to build up dependencies correctly. 