### PR TITLE
Debug app starting (bug #200)

### DIFF
--- a/yin_yang/__main__.py
+++ b/yin_yang/__main__.py
@@ -12,7 +12,7 @@ from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QSystemTrayIcon, QMenu
 from systemd import journal
 
-from NotificationHandler import NotificationHandler
+from yin_yang.NotificationHandler import NotificationHandler
 from yin_yang import daemon_handler
 from yin_yang.meta import ConfigEvent
 from yin_yang import theme_switcher

--- a/yin_yang/plugins/wallpaper.py
+++ b/yin_yang/plugins/wallpaper.py
@@ -59,6 +59,8 @@ class _Gnome(PluginCommandline):
 
 
 def check_theme(theme: str) -> bool:
+    if not theme:
+        return False
     file = Path(theme)
     if "#" in file.name:
         logger.error('Image files that contain a \'#\' will not work.')


### PR DESCRIPTION
I had the same error as in #200. After installing version from beta I got:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/yin-yang/yin_yang/__main__.py", line 15, in <module>
    from NotificationHandler import NotificationHandler
ModuleNotFoundError: No module named 'NotificationHandler'
```

I looked into `__main__.py` and changed the import statement to relative.

After that the error message changed to:
```
Plugin Icons has no support for your desktop environment yet!
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/yin-yang/yin_yang/__main__.py", line 16, in <module>
    from yin_yang import daemon_handler
  File "/opt/yin-yang/yin_yang/daemon_handler.py", line 7, in <module>
    from .config import ConfigWatcher, config
  File "/opt/yin-yang/yin_yang/config.py", line 492, in <module>
    config = ConfigManager()
             ^^^^^^^^^^^^^^^
  File "/opt/yin-yang/yin_yang/config.py", line 192, in __init__
    self.load()
  File "/opt/yin-yang/yin_yang/config.py", line 259, in load
    pl.theme_light = config_loaded['plugins'][pl.name.lower()]['light_theme']
    ^^^^^^^^^^^^^^
  File "/opt/yin-yang/yin_yang/plugins/_plugin.py", line 220, in theme_light
    self.strategy.theme_light = value
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/yin-yang/yin_yang/plugins/wallpaper.py", line 87, in theme_light
    check_theme(value)
  File "/opt/yin-yang/yin_yang/plugins/wallpaper.py", line 62, in check_theme
    file = Path(theme)
           ^^^^^^^^^^^
  File "/usr/lib/python3.11/pathlib.py", line 871, in __new__
    self = cls._from_parts(args)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/pathlib.py", line 509, in _from_parts
    drv, root, parts = self._parse_args(args)
                       ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/pathlib.py", line 493, in _parse_args
    a = os.fspath(a)
        ^^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

After adding some fallback to `wallpaper.py` everything seems to be working. I still get:
```
Plugin Icons has no support for your desktop environment yet!
Brak schematu „org.gnome.gedit.preferences.editor”
Error while loading translation. Using default language.
Brak schematu „org.gnome.gedit.preferences.editor”
QDBusConnection: error: could not send signal to service "" path "//home/jakub/.config/kdedefaults/kdeglobals" interface "org.kde.kconfig.notify" member "ConfigChanged": Invalid object path: //home/jakub/.config/kdedefaults/kdeglobals
QDBusConnection: error: could not send signal to service "" path "//home/jakub/.config/kdedefaults/kdeglobals" interface "org.kde.kconfig.notify" member "ConfigChanged": Invalid object path: //home/jakub/.config/kdedefaults/kdeglobals
QDBusConnection: error: could not send signal to service "" path "//home/jakub/.config/kdedefaults/kcminputrc" interface "org.kde.kconfig.notify" member "ConfigChanged": Invalid object path: //home/jakub/.config/kdedefaults/kcminputrc
QDBusConnection: error: could not send signal to service "" path "//home/jakub/.config/kdedefaults/kwinrc" interface "org.kde.kconfig.notify" member "ConfigChanged": Invalid object path: //home/jakub/.config/kdedefaults/kwinrc
```
...in the console but it doesn't seem to influence the program. the path shouldn't start with two slashes but it might be a different bug, not connected to #200.