### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,19 @@ Yin-Yang depends on `python-systemd` and `pyside6` from pypi. `python-systemd` r
 
 For CentOS, RHEL, and Fedora:
 ```bash
-sudo dnf install gcc systemd-devel python3-devel
+sudo dnf install gcc systemd-devel python3-devel libnotify
 ``` 
 
 For OpenSUSE:
 ```bash
 sudo zypper refresh
-sudo zypper install gcc systemd-devel
+sudo zypper install gcc systemd-devel libnotify
 ```
 
 For Debian, Ubuntu, etc.
 ```bash
 sudo apt update
-sudo apt install libsystemd-dev gcc pkg-config python3-dev
+sudo apt install libsystemd-dev gcc pkg-config python3-dev libnotify-bin
 ```
 
 Then you can install Yin-Yang in a python virtual environment:


### PR DESCRIPTION
Added `libnotify` to prerequisites. Without it, Yin-Yang installs but crashes when launched, saying 'no such file or folder: 'notify-send'' (I have Kubuntu 23.10, but I think that without `notify-send` installed errors are likely to be present on other systems as well.