### PR TITLE
Refactor DBus plugin and its child plugins

### DIFF
--- a/yin_yang/__main__.py
+++ b/yin_yang/__main__.py
@@ -19,7 +19,7 @@ from yin_yang import theme_switcher
 from yin_yang.config import config, Modes
 from yin_yang.ui import main_window_connector
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def setup_logger(use_systemd_journal: bool):
@@ -97,7 +97,7 @@ else:
         logger.debug(f'Using language {lang}')
 
         # system translations
-        path = QLibraryInfo.path(QLibraryInfo.TranslationsPath)
+        path = QLibraryInfo.path(QLibraryInfo.LibraryPath.TranslationsPath)
         translator = QTranslator(app)
         if translator.load(QLocale.system(), 'qtbase', '_', path):
             app.installTranslator(translator)

--- a/yin_yang/plugins/__init__.py
+++ b/yin_yang/plugins/__init__.py
@@ -1,3 +1,4 @@
+from typing import List
 from ..meta import Desktop
 from . import system, colors, gtk, icons, kvantum, wallpaper, custom
 from . import firefox, only_office, okular
@@ -9,7 +10,7 @@ from . import notify
 from yin_yang.plugins._plugin import Plugin, ExternalPlugin
 
 
-def get_plugins(desktop: Desktop) -> [Plugin]:
+def get_plugins(desktop: Desktop) -> List[Plugin]:
     return [
         system.System(desktop),
         colors.Colors(desktop),

--- a/yin_yang/plugins/_plugin.py
+++ b/yin_yang/plugins/_plugin.py
@@ -254,11 +254,11 @@ class ExternalPlugin(Plugin):
 
 class DBusPlugin(Plugin):
     """A class for plugins that mainly switching theme via DBus"""
-    def __init__(self):
+    def __init__(self, message_data: List[str]):
         super().__init__()
         self.connection = QDBusConnection.sessionBus()
         self.message = QDBusMessage()
-        self.message_data: List[str] = ['' for _ in range(4)]  # Store DBusMessage data(destination, path, interface, method)
+        self.message_data: List[str] = message_data  # Store DBusMessage data(destination, path, interface, method)
 
     def set_theme(self, theme: str):
         """Check arguments, create DBus message and then call"""

--- a/yin_yang/plugins/_plugin.py
+++ b/yin_yang/plugins/_plugin.py
@@ -279,7 +279,7 @@ class DBusPlugin(Plugin):
         return self.connection.call(self.message)
 
     def list_paths(self, service: str, path: str) -> List[str]:
-        """ Get all subpath under given pth of service
+        """ Get all subpath under a given pth of service
         :path: should start with / but without / on its end
         """
         assert path.startswith('/') and not path.endswith('/'), "list_paths wrong, :path: should start with / but without / on its end"

--- a/yin_yang/plugins/_plugin.py
+++ b/yin_yang/plugins/_plugin.py
@@ -268,11 +268,11 @@ class DBusPlugin(Plugin):
         if not theme:
             raise ValueError(f'Theme \"{theme}\" is invalid')
 
-        self.create_message(theme)
+        self.message = self.create_message(theme)
         self.call()
 
     @abstractmethod
-    def create_message(self, theme: str) -> None:
+    def create_message(self, theme: str) -> QDBusMessage:
         raise NotImplementedError(f'Plugin {self.name} did not implement create_message()')
 
     def call(self) -> QDBusMessage:

--- a/yin_yang/plugins/_plugin.py
+++ b/yin_yang/plugins/_plugin.py
@@ -257,7 +257,7 @@ class DBusPlugin(Plugin):
     def __init__(self, message_data: List[str]):
         super().__init__()
         self.connection = QDBusConnection.sessionBus()
-        self.message = QDBusMessage()
+        self.message: QDBusMessage
         self.message_data: List[str] = message_data  # Store DBusMessage data(destination, path, interface, method)
 
     def set_theme(self, theme: str):

--- a/yin_yang/plugins/gtk.py
+++ b/yin_yang/plugins/gtk.py
@@ -77,9 +77,10 @@ class _Kde(DBusPlugin):
         self.theme_light = 'Breeze'
         self.theme_dark = 'Breeze'
 
-    def create_message(self, theme: str):
-        self.message = QDBusMessage.createMethodCall(*self.message_data)
-        self.message.setArguments([theme])
+    def create_message(self, theme: str) -> QDBusMessage:
+        message = QDBusMessage.createMethodCall(*self.message_data)
+        message.setArguments([theme])
+        return message
 
     def set_theme(self, theme: str):
         """Call DBus interface of kde-gtk-config if installed.

--- a/yin_yang/plugins/gtk.py
+++ b/yin_yang/plugins/gtk.py
@@ -73,10 +73,9 @@ class _Kde(DBusPlugin):
         return 'GTK'
 
     def __init__(self):
-        super().__init__()
+        super().__init__(['org.kde.GtkConfig', '/GtkConfig', 'org.kde.GtkConfig', 'setGtkTheme'])
         self.theme_light = 'Breeze'
         self.theme_dark = 'Breeze'
-        self.message_data = ['org.kde.GtkConfig', '/GtkConfig', 'org.kde.GtkConfig', 'setGtkTheme']
 
     def create_message(self, theme: str):
         self.message = QDBusMessage.createMethodCall(*self.message_data)

--- a/yin_yang/plugins/gtk.py
+++ b/yin_yang/plugins/gtk.py
@@ -52,8 +52,8 @@ class _Gnome(PluginCommandline):
     @property
     def available(self) -> bool:
         return test_gnome_availability(self.command)
-    
-    
+
+
 class _Budgie(PluginCommandline):
     name = 'GTK'
 
@@ -83,10 +83,11 @@ class _Kde(DBusPlugin):
         self.message.setArguments([theme])
 
     def set_theme(self, theme: str):
-        """Call DBus interface of kde-ftk-config if installed.
+        """Call DBus interface of kde-gtk-config if installed.
         Otherwise try changing xsettingsd's conf and dconf"""
 
-        if self.connection.interface().isServiceRegistered('org.kde.GtkConfig'):
+        if self.connection.interface().isServiceRegistered('org.kde.GtkConfig').value():
+            logger.debug("Detected kde-gtk-config, use it")
             super().set_theme(theme)
             return
 
@@ -110,7 +111,7 @@ class _Kde(DBusPlugin):
         subprocess.run(['killall', '-HUP', 'xsettingsd'])
 
         # change dconf db. since dconf sending data as GVariant, use gsettings instead
-        subprocess.run(['gsettings', 'set', 'org.gnome.desktop.interface', 'gtk-theme', '{theme}'])
+        subprocess.run(['gsettings', 'set', 'org.gnome.desktop.interface', 'gtk-theme', f'{theme}'])
         color_scheme = 'prefer-dark' if theme == self.theme_dark else 'prefer-light'
         subprocess.run(['gsettings', 'set', 'org.gnome.desktop.interface', 'color-scheme', f'{color_scheme}'])
 

--- a/yin_yang/plugins/konsole.py
+++ b/yin_yang/plugins/konsole.py
@@ -1,21 +1,19 @@
 import logging
 import os
 import re
-import subprocess
 from configparser import ConfigParser
 from itertools import chain
 from pathlib import Path
 from shutil import copyfile
 
-import psutil
-from PySide6.QtDBus import QDBusConnection, QDBusMessage
+from PySide6.QtDBus import QDBusMessage
 
-from ._plugin import Plugin
+from ._plugin import DBusPlugin
 
 logger = logging.getLogger(__name__)
 
 
-class Konsole(Plugin):
+class Konsole(DBusPlugin):
     """
     Themes are profiles. To use a color scheme,
     create a new profile or edit one to use the desired color scheme.
@@ -24,12 +22,15 @@ class Konsole(Plugin):
     global_path = Path('/usr/share/konsole')
     config_path = Path.home() / '.config/konsolerc'
 
+    apps_have_konsole = ["org.kde.konsole", "org.kde.yakuake", "org.kde.dolphin", "org.kde.kate"]
+    """ All apps that can using kobnsole, need expand """
+
     @property
     def user_path(self) -> Path:
         return Path.home() / '.local/share/konsole'
 
     def __init__(self):
-        super().__init__()
+        super().__init__(['org.kde.konsole', 'Sessions/', 'org.kde.konsole.Session', 'setProfile'])
         self._theme_light = 'BlackOnWhite'
         self._theme_dark = 'Breeze'
 
@@ -51,6 +52,10 @@ class Konsole(Plugin):
         self.update_profile(True, value)
         self._theme_dark = value
 
+    def create_message(self, theme: str):
+        message = QDBusMessage.createMethodCall(*self.message_data)
+        message.setArguments([theme])
+
     def set_mode(self, dark: bool) -> bool:
         # run checks
         if not super().set_mode(dark):
@@ -61,41 +66,17 @@ class Konsole(Plugin):
         # update default profile, if application is started afterward
         self.default_profile = profile + '.profile'
 
-        # Set Konsole profile for all sessions
-
-        # Get the process IDs of all running Konsole instances owned by the current user
-        process_ids = [
-            proc.pid for proc in psutil.process_iter()
-            if proc.name() == 'konsole' and proc.username() == os.getlogin()
-        ]
-
-        # loop: console processes
-        for proc_id in process_ids:
-            logger.debug(f'Changing profile in konsole session {proc_id}')
-            set_profile(f'org.kde.konsole-{proc_id}', profile)
-            set_profile(f'org.kde.konsole-{proc_id}', profile, set_default_profile=True)
-
-        # konsole may don't have session dbus like above
-        set_profile('org.kde.konsole', profile)
-        set_profile('org.kde.yakuake', profile)
-        set_profile('org.kde.konsole', profile, set_default_profile=True)
-        set_profile('org.kde.yakuake', profile, set_default_profile=True)
-
-        process_ids = [
-            proc.pid for proc in psutil.process_iter()
-            if proc.name() == 'dolphin' and proc.username() == os.getlogin()
-        ]
-
-        # loop: dolphin processes
-        for proc_id in process_ids:
-            logger.debug(f'Changing profile in dolphin session {proc_id}')
-            set_profile(f'org.kde.dolphin-{proc_id}', profile)
-            set_profile(f'org.kde.dolphin-{proc_id}',
-                        profile, set_default_profile=True)
+        # Find available konsole sessions, including dolphin, yakuake, kate, etc
+        services = [str(n) for n in self.connection.interface().registeredServiceNames().value()
+                    if n.split('-')[0] in self.apps_have_konsole]
+        for service in services:
+            logger.debug(f'Changing profile in konsole session {service}')
+            self.set_profile(service, profile=profile)
+            self.set_profile(service, profile, set_default_profile=True)
 
         return True
 
-    def set_theme(self, theme: str):
+    def set_theme(self, theme: str):  # type: ignore
         # everything is done in set_mode (above)
         pass
 
@@ -175,6 +156,7 @@ Parent=FALLBACK/
 
         with self.config_path.open('r') as file:
             lines = file.readlines()
+            match: re.Match[str] | None = None
             for i, line in enumerate(lines):
                 # Search for the pattern "DefaultProfile=*"
                 match = re.search(r'DefaultProfile=(.*)', line)
@@ -184,10 +166,12 @@ Parent=FALLBACK/
                     logger.debug(f'Changing default profile to {value}')
                     lines[i] = f'DefaultProfile={value}\n'
                     break
-                else:
-                    logger.debug('No default profile found')
-        with self.config_path.open('w') as file:
-            file.writelines(lines)
+
+            if match is None:
+                logger.error(f'No DefaultProfile field found in {self.config_path}')
+            else:
+                with self.config_path.open('w') as file:
+                    file.writelines(lines)
 
     def update_profile(self, dark: bool, theme: str):
         if not self.available or theme == '':
@@ -202,7 +186,7 @@ Parent=FALLBACK/
             self.create_profiles()
 
         profile_config = ConfigParser()
-        profile_config.optionxform = str
+        profile_config.optionxform = lambda optionstr: optionstr
         profile_config.read(file_path)
 
         try:
@@ -225,7 +209,7 @@ Parent=FALLBACK/
 
         # Change name in file
         profile_config = ConfigParser()
-        profile_config.optionxform = str
+        profile_config.optionxform = lambda optionstr: optionstr
 
         profile_config.read(light_profile)
         profile_config['General']['Name'] = light_profile.stem
@@ -239,47 +223,25 @@ Parent=FALLBACK/
         with open(dark_profile, 'w') as file:
             profile_config.write(file)
 
+    def set_profile(self, service: str, profile: str, set_default_profile: bool = False):
+        if set_default_profile:
+            path = '/Sessions'
+            interface = 'org.kde.konsole.Session'
+            method = 'setProfile'
+        else:
+            path = '/Windows'
+            interface = 'org.kde.konsole.Window'
+            method = 'setDefaultProfile'
 
-def set_profile(service: str, profile: str, set_default_profile: bool = False):
-    # connect to the session bus
-    connection = QDBusConnection.sessionBus()
-    if set_default_profile:
-        path = 'Sessions/'
-        interface = 'org.kde.konsole.Session'
-        method = 'setProfile'
-    else:
-        path = 'Windows/'
-        interface = 'org.kde.konsole.Window'
-        method = 'setDefaultProfile'
-
-    # maybe it's possible with pyside6 dbus packages, but this was simpler and worked
-    try:
-        sessions = subprocess.check_output(
-            f'qdbus {service} | grep "{path}"', shell=True)
-    except subprocess.CalledProcessError:
-        try:
-            sessions = subprocess.check_output(
-                f'qdbus org.kde.konsole | grep "{path}"', shell=True
-            )
-            logger.debug(f'Found org.kde.konsole, use that instead')
-            service = "org.kde.konsole"
-        except subprocess.CalledProcessError:
-            # happens when dolphins konsole is not opened
+        for path in self.list_paths(service, path):
             logger.debug(
-                f'No Konsole sessions available in service {service}, skipping')
-            return
-    sessions = sessions.decode('utf-8').removesuffix('\n').split('\n')
-
-    # loop: process sessions
-    for session in sessions:
-        logger.debug(
-            f'Changing {"default" if set_default_profile else ""} profile of session {session} to {profile}')
-        # set profile
-        message = QDBusMessage.createMethodCall(
-            service,
-            session,
-            interface,
-            method
-        )
-        message.setArguments([profile])
-        connection.call(message)
+                f'Changing {"default" if set_default_profile else ""} profile of {path} to {profile}')
+            # set profile
+            message = QDBusMessage.createMethodCall(
+                service,
+                path,
+                interface,
+                method
+            )
+            message.setArguments([profile])
+            self.connection.call(message)

--- a/yin_yang/plugins/konsole.py
+++ b/yin_yang/plugins/konsole.py
@@ -52,9 +52,10 @@ class Konsole(DBusPlugin):
         self.update_profile(True, value)
         self._theme_dark = value
 
-    def create_message(self, theme: str):
+    def create_message(self, theme: str) -> QDBusMessage:
         message = QDBusMessage.createMethodCall(*self.message_data)
         message.setArguments([theme])
+        return message
 
     def set_mode(self, dark: bool) -> bool:
         # run checks

--- a/yin_yang/plugins/notify.py
+++ b/yin_yang/plugins/notify.py
@@ -1,14 +1,12 @@
-from PySide6.QtDBus import QDBusMessage
-
 from ..NotificationHandler import create_dbus_message
 from ._plugin import DBusPlugin
 
 
 class Notification(DBusPlugin):
     def __init__(self):
-        super().__init__()
-        self.theme_light = 'Day'
-        self.theme_dark = 'Night'
+        super().__init__([])  # We do everything in [create_dbus_message]
+        self.theme_light = "Day"
+        self.theme_dark = "Night"
 
-    def create_message(self, theme: str) -> QDBusMessage:
-        return create_dbus_message('Theme changed', f'Set the theme to {theme}')
+    def create_message(self, theme: str):
+        self.message = create_dbus_message("Theme changed", f"Set the theme to {theme}")

--- a/yin_yang/plugins/notify.py
+++ b/yin_yang/plugins/notify.py
@@ -1,3 +1,5 @@
+from PySide6.QtDBus import QDBusMessage
+
 from ..NotificationHandler import create_dbus_message
 from ._plugin import DBusPlugin
 
@@ -8,5 +10,5 @@ class Notification(DBusPlugin):
         self.theme_light = "Day"
         self.theme_dark = "Night"
 
-    def create_message(self, theme: str):
-        self.message = create_dbus_message("Theme changed", f"Set the theme to {theme}")
+    def create_message(self, theme: str) -> QDBusMessage:
+        return create_dbus_message("Theme changed", f"Set the theme to {theme}")

--- a/yin_yang/plugins/wallpaper.py
+++ b/yin_yang/plugins/wallpaper.py
@@ -2,11 +2,11 @@ import logging
 import subprocess
 from pathlib import Path
 
-from PySide6.QtWidgets import QDialogButtonBox, QVBoxLayout, QWidget, QLineEdit
-from PySide6.QtDBus import QDBusMessage
+from PySide6.QtWidgets import QDialogButtonBox, QLineEdit, QVBoxLayout, QWidget
+
+from yin_yang.plugins._plugin import PluginCommandline, PluginDesktopDependent
 
 from ..meta import Desktop
-from yin_yang.plugins._plugin import PluginDesktopDependent, PluginCommandline, DBusPlugin
 from .system import test_gnome_availability
 
 logger = logging.getLogger(__name__)
@@ -86,16 +86,15 @@ def check_theme(theme: str) -> bool:
     return True
 
 
-class _Kde(DBusPlugin):
+class _Kde(PluginCommandline):
     @property
     def name(self):
         return 'Wallpaper'
 
     def __init__(self):
-        super().__init__()
+        super().__init__(['/usr/bin/plasma-apply-wallpaperimage', '{theme}'])
         self._theme_light = None
         self._theme_dark = None
-        self.message_data = ['org.kde.plasmashell', '/PlasmaShell', 'org.kde.PlasmaShell', 'evaluateScript']
 
     @property
     def theme_light(self):
@@ -118,19 +117,6 @@ class _Kde(DBusPlugin):
     @property
     def available(self) -> bool:
         return True
-
-    def create_message(self, theme: str):
-        message = QDBusMessage.createMethodCall(*self.message_data)
-        message.setArguments([
-            'string:'
-            'var Desktops = desktops();'
-            'for (let i = 0; i < Desktops.length; i++) {'
-            '    let d = Desktops[i];'
-            '    d.wallpaperPlugin = "org.kde.image";'
-            '    d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");'
-            f'    d.writeConfig("Image", "file:{theme}");'
-            '}'
-        ])
 
 
 class _Xfce(PluginCommandline):

--- a/yin_yang/plugins/wallpaper.py
+++ b/yin_yang/plugins/wallpaper.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import QDialogButtonBox, QVBoxLayout, QWidget, QLineEdit
 from PySide6.QtDBus import QDBusMessage
 
 from ..meta import Desktop
-from ._plugin import PluginDesktopDependent, PluginCommandline, DBusPlugin
+from yin_yang.plugins._plugin import PluginDesktopDependent, PluginCommandline, DBusPlugin
 from .system import test_gnome_availability
 
 logger = logging.getLogger(__name__)
@@ -87,15 +87,18 @@ def check_theme(theme: str) -> bool:
 
 
 class _Kde(DBusPlugin):
-    name = 'Wallpaper'
+    @property
+    def name(self):
+        return 'Wallpaper'
 
     def __init__(self):
         super().__init__()
         self._theme_light = None
         self._theme_dark = None
+        self.message_data = ['org.kde.plasmashell', '/PlasmaShell', 'org.kde.PlasmaShell', 'evaluateScript']
 
     @property
-    def theme_light(self) -> str:
+    def theme_light(self):
         return self._theme_light
 
     @theme_light.setter
@@ -104,7 +107,7 @@ class _Kde(DBusPlugin):
         self._theme_light = value
 
     @property
-    def theme_dark(self) -> str:
+    def theme_dark(self):
         return self._theme_dark
 
     @theme_dark.setter
@@ -116,13 +119,8 @@ class _Kde(DBusPlugin):
     def available(self) -> bool:
         return True
 
-    def create_message(self, theme: str) -> QDBusMessage:
-        message = QDBusMessage.createMethodCall(
-            'org.kde.plasmashell',
-            '/PlasmaShell',
-            'org.kde.PlasmaShell',
-            'evaluateScript',
-        )
+    def create_message(self, theme: str):
+        message = QDBusMessage.createMethodCall(*self.message_data)
         message.setArguments([
             'string:'
             'var Desktops = desktops();'
@@ -133,7 +131,6 @@ class _Kde(DBusPlugin):
             f'    d.writeConfig("Image", "file:{theme}");'
             '}'
         ])
-        return message
 
 
 class _Xfce(PluginCommandline):

--- a/yin_yang/plugins/wallpaper.py
+++ b/yin_yang/plugins/wallpaper.py
@@ -2,11 +2,11 @@ import logging
 import subprocess
 from pathlib import Path
 
-from PySide6.QtWidgets import QDialogButtonBox, QLineEdit, QVBoxLayout, QWidget
-
-from yin_yang.plugins._plugin import PluginCommandline, PluginDesktopDependent
+from PySide6.QtWidgets import QDialogButtonBox, QVBoxLayout, QWidget, QLineEdit
+from PySide6.QtDBus import QDBusMessage
 
 from ..meta import Desktop
+from yin_yang.plugins._plugin import PluginDesktopDependent, PluginCommandline, DBusPlugin
 from .system import test_gnome_availability
 
 logger = logging.getLogger(__name__)
@@ -86,15 +86,16 @@ def check_theme(theme: str) -> bool:
     return True
 
 
-class _Kde(PluginCommandline):
+class _Kde(DBusPlugin):
     @property
     def name(self):
         return 'Wallpaper'
 
     def __init__(self):
-        super().__init__(['/usr/bin/plasma-apply-wallpaperimage', '{theme}'])
+        super().__init__()
         self._theme_light = None
         self._theme_dark = None
+        self.message_data = ['org.kde.plasmashell', '/PlasmaShell', 'org.kde.PlasmaShell', 'evaluateScript']
 
     @property
     def theme_light(self):
@@ -117,6 +118,19 @@ class _Kde(PluginCommandline):
     @property
     def available(self) -> bool:
         return True
+
+    def create_message(self, theme: str):
+        message = QDBusMessage.createMethodCall(*self.message_data)
+        message.setArguments([
+            'string:'
+            'var Desktops = desktops();'
+            'for (let i = 0; i < Desktops.length; i++) {'
+            '    let d = Desktops[i];'
+            '    d.wallpaperPlugin = "org.kde.image";'
+            '    d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");'
+            f'    d.writeConfig("Image", "file:{theme}");'
+            '}'
+        ])
 
 
 class _Xfce(PluginCommandline):

--- a/yin_yang/plugins/wallpaper.py
+++ b/yin_yang/plugins/wallpaper.py
@@ -92,10 +92,9 @@ class _Kde(DBusPlugin):
         return 'Wallpaper'
 
     def __init__(self):
-        super().__init__()
+        super().__init__(['org.kde.plasmashell', '/PlasmaShell', 'org.kde.PlasmaShell', 'evaluateScript'])
         self._theme_light = None
         self._theme_dark = None
-        self.message_data = ['org.kde.plasmashell', '/PlasmaShell', 'org.kde.PlasmaShell', 'evaluateScript']
 
     @property
     def theme_light(self):

--- a/yin_yang/plugins/wallpaper.py
+++ b/yin_yang/plugins/wallpaper.py
@@ -118,7 +118,7 @@ class _Kde(DBusPlugin):
     def available(self) -> bool:
         return True
 
-    def create_message(self, theme: str):
+    def create_message(self, theme: str) -> QDBusMessage:
         message = QDBusMessage.createMethodCall(*self.message_data)
         message.setArguments([
             'string:'
@@ -130,6 +130,7 @@ class _Kde(DBusPlugin):
             f'    d.writeConfig("Image", "file:{theme}");'
             '}'
         ])
+        return message
 
 
 class _Xfce(PluginCommandline):


### PR DESCRIPTION
Working on the following:

- [x] refactor parent class of DBus plugin, avoid using cli but using pyside6 dbus package, since some distros like Arch using `qdbus6` as binary name but some distros are not.
- [x] Port wallpaper(_kde) plugin to use DBus
- [x] Port gtk-kde-plugin to the new DBus plugin, using dconf and xsettingsd as fallback
- [x] konsole-plugin to the new DBus plugin