### PR TITLE
fix: ensure konsole dir exists

### DIFF
--- a/yin_yang/plugins/konsole.py
+++ b/yin_yang/plugins/konsole.py
@@ -122,6 +122,9 @@ class Konsole(Plugin):
     @property
     def default_profile(self):
         value = None
+        # Ensure directory exists
+        Path(self.user_path).mkdir(parents=True, exist_ok=True)
+
         # cant use config parser because of weird file structure
         with self.config_path.open('r') as file:
             for line in file:


### PR DESCRIPTION
On AwesomeWM without a KDE setup this caused Yin-Yang to fail starting up.