### PR TITLE
Change translation error to warning to prevent user notifications.

### DIFF
--- a/yin_yang/__main__.py
+++ b/yin_yang/__main__.py
@@ -113,7 +113,7 @@ else:
             raise FileNotFoundError('Error while loading application translations!')
 
     except Exception as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         print('Error while loading translation. Using default language.')
 
     # show systray icon


### PR DESCRIPTION
Users were being shown a notification when translations didn't load, which includes when a translation was not needed (English). This change stops that.

This may solve #305 