### PR TITLE
Fix path in konsole.py

### DIFF
--- a/yin_yang/plugins/konsole.py
+++ b/yin_yang/plugins/konsole.py
@@ -239,11 +239,11 @@ Parent=FALLBACK/
 
     def set_profile(self, service: str, profile: str, set_default_profile: bool = False):
         if set_default_profile:
-            path = 'Sessions/'
+            path = '/Sessions'
             interface = 'org.kde.konsole.Session'
             method = 'setProfile'
         else:
-            path = 'Windows/'
+            path = '/Windows'
             interface = 'org.kde.konsole.Window'
             method = 'setDefaultProfile'
 


### PR DESCRIPTION
https://github.com/oskarsh/Yin-Yang/blob/508b167fc41761b5165d2c5f4b1a71fc04e29235/yin_yang/plugins/_plugin.py#L284C1-L284C136 requires that `path` start with `'/'` and not end with `'/'`, while the path in `konsole.py` is in the opposite format.

Tested locally with Konsole