### PR TITLE
icons: improve icon theme check to exclude cursor themes

### DIFF
--- a/yin_yang/plugins/icons.py
+++ b/yin_yang/plugins/icons.py
@@ -120,7 +120,10 @@ class _Kde(PluginCommandline):
                 theme_parser.read(icon_theme_folder.path + "/index.theme")
                 theme_name = theme_parser["Icon Theme"]["Name"]
 
-                themes.append((icon_theme_folder.name, theme_name))
+                # this will exclude any icon themes that aren't icons, such as cursors
+                # https://specifications.freedesktop.org/icon-theme-spec/latest/#id-1.5.4.1
+                if any("Size" in theme_parser[s] for s in theme_parser.sections()):
+                    themes.append((icon_theme_folder.name, theme_name))
 
         return dict(themes)
 


### PR DESCRIPTION
Fixes #338.

This PR checks the `index.theme` for [mandatory Size fields](https://specifications.freedesktop.org/icon-theme-spec/latest/#id-1.5.4.1) to make sure it's an icon th eme and not a cursor theme.

As mentioned before, XCursor files can support multiple resolutions embedded into one file, so cursor themes will not have this value set (unless if they're also an icon theme).