### PR TITLE
fix: resolve window NameError when started with --minimized

### DIFF
--- a/yin_yang/__main__.py
+++ b/yin_yang/__main__.py
@@ -127,6 +127,9 @@ else:
         logger.warning(str(e))
         print('The app has not been translated to your language yet. Using default language.')
 
+    # Create the window object before setting up system tray
+    window = main_window_connector.MainWindow()
+
     # show systray icon
     if QSystemTrayIcon.isSystemTrayAvailable():
         app.setQuitOnLastWindowClosed(False)
@@ -151,9 +154,8 @@ else:
     else:
         logger.debug('System tray is unsupported')
 
-    if arguments.minimized:
-        sys.exit(app.exec())
-    else:
-        window = main_window_connector.MainWindow()
+    # Show the window only if not started minimized
+    if not arguments.minimized:
         window.show()
-        sys.exit(app.exec())
+    
+    sys.exit(app.exec())


### PR DESCRIPTION
TLDR: Fixes #299

This pull request refactors the initialization logic for the system tray and main window in the `yin_yang/__main__.py` file. The changes ensure that the main window object is created earlier in the process and simplify the logic for handling minimized startup.

Refactoring of system tray and window initialization:

* [`yin_yang/__main__.py`](diffhunk://#diff-e51f7bc2fb92ef7456b51c7567188ebb5c527178a7908d78401ba9eec1ffbd0eR130-R132): Added the creation of the `MainWindow` object (`window`) before setting up the system tray to ensure it is initialized regardless of startup mode.
* [`yin_yang/__main__.py`](diffhunk://#diff-e51f7bc2fb92ef7456b51c7567188ebb5c527178a7908d78401ba9eec1ffbd0eL154-R160): Simplified the logic for minimized startup by removing redundant code and ensuring the window is only shown when not started minimized.