### PR TITLE
fix: you need to specify a desktop-entry file to create or augment as output

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,7 +48,7 @@ cp ./resources/yin_yang.json /usr/lib/mozilla/native-messaging-hosts/
 # copy terminal executive
 cp ./resources/yin_yang /usr/bin/
 # copy .desktop file
-appstreamcli make-desktop-file "$USER_HOME/.local/share/applications/yin_yang.desktop"
+appstreamcli make-desktop-file resources/sh.oskar.yin_yang.metainfo.xml "$USER_HOME/.local/share/applications/yin_yang.desktop"
 # copy icon
 cp ./resources/icon.svg /usr/share/icons/hicolor/scalable/apps/sh.oskar.yin_yang.svg
 # systemd unit files will be installed by the app


### PR DESCRIPTION
This pull request updates the `scripts/install.sh` file to ensure proper installation of the `.desktop` file by specifying the correct source file for the `appstreamcli` command.

* [`scripts/install.sh`](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccL51-R51): Modified the `appstreamcli` command to use `resources/sh.oskar.yin_yang.metainfo.xml` as the source file for creating the `.desktop` file, replacing the previous unspecified source.